### PR TITLE
export transformScriptTags

### DIFF
--- a/examples/scriptTag-custom.htm
+++ b/examples/scriptTag-custom.htm
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8" />
+  <title>babel-standalone example - Script tag</title>
+</head>
+<body>
+  Using Babel <strong id="version"></strong>:
+  <pre id="output">Loading...</pre>
+
+  <script src="../babel.js"></script>
+  <script type="text/javascript">
+    // just disable the auto transformation
+    Babel.disableScriptTags();
+
+    var script = document.createElement('script');
+    script.type = 'text/babel';
+    script.text = "const doStuff = () => {" + 
+                  "  const name = 'world';" +
+                  "  document.getElementById('output').innerHTML = `Hello ${name}`;" +
+                  "  document.getElementById('version').innerHTML = Babel.version;" +
+                  "};" +
+                  "doStuff();";
+    document.querySelector('head').appendChild(script)
+
+    // transform when you want to
+    Babel.transformScriptTags()
+  </script>
+</body>
+</html>

--- a/src/index.js
+++ b/src/index.js
@@ -255,9 +255,16 @@ export const version = VERSION;
 
 // Listen for load event if we're in a browser and then kick off finding and
 // running of scripts with "text/babel" type.
-const transformScriptTags = () => runScripts(transform);
 if (typeof window !== 'undefined' && window && window.addEventListener) {
   window.addEventListener('DOMContentLoaded', transformScriptTags, false);
+}
+
+/**
+ * Transform <script> tags with "text/babel" type.
+ * @param {Array} scriptTags specify script tags to transform, transform all in the <head> if not given
+ */
+export function transformScriptTags(scriptTags) {
+  runScripts(transform, scriptTags);
 }
 
 /**
@@ -266,3 +273,4 @@ if (typeof window !== 'undefined' && window && window.addEventListener) {
 export function disableScriptTags() {
   window.removeEventListener('DOMContentLoaded', transformScriptTags);
 }
+

--- a/src/transformScriptTags.js
+++ b/src/transformScriptTags.js
@@ -181,11 +181,17 @@ function loadScripts(transformFn, scripts) {
 }
 
 /**
- * Find and run all script tags with type="text/jsx".
+ * Run script tags with type="text/jsx".
+ * @param {Array} scriptTags specify script tags to run, run all in the <head> if not given
  */
-export function runScripts(transformFn) {
-  headEl = document.getElementsByTagName('head')[0];
-  const scripts = document.getElementsByTagName('script');
+export function runScripts(transformFn, scriptTags) {
+  let scripts
+  if(scriptTags) {
+    scripts = scriptTags
+  } else {
+    headEl = document.getElementsByTagName('head')[0];
+    scripts = document.getElementsByTagName('script');
+  }
 
   // Array.prototype.slice cannot be used on NodeList on IE8
   const jsxScripts = [];

--- a/src/transformScriptTags.js
+++ b/src/transformScriptTags.js
@@ -186,10 +186,10 @@ function loadScripts(transformFn, scripts) {
  */
 export function runScripts(transformFn, scriptTags) {
   let scripts
+  headEl = document.getElementsByTagName('head')[0];
   if(scriptTags) {
     scripts = scriptTags
   } else {
-    headEl = document.getElementsByTagName('head')[0];
     scripts = document.getElementsByTagName('script');
   }
 


### PR DESCRIPTION
Resolved #80 

And I add an argument to the function transfromScriptTags/runScripts to specify what should be transform/run. This is not break original usage.

By exported this function, it will lead to multiple executions with a common script tag, if you call transfromScriptTags before DOMContentLoaded without disableScriptTags, so I also add an example instead of fixes this problem, because fixing it need a little more works, anyway this is not break change.