### PR TITLE
Allow users to specify a module for inline scripts

### DIFF
--- a/src/transformScriptTags.js
+++ b/src/transformScriptTags.js
@@ -172,7 +172,7 @@ function loadScripts(transformFn, scripts) {
         ...scriptData,
         content: script.innerHTML,
         loaded: true,
-        url: null,
+        url: script.getAttribute('data-module'),
       };
     }
   });


### PR DESCRIPTION
Currently inline scripts cannot be referenced via imports. With this change they can be if you specify a `data-module` attribute on the script tag:

```
<!doctype html>
<html>
<head>
  <title>Babel Test</title>
</head>
<body>
  <script src="./babel.js"></script>
  <script data-plugins="transform-es2015-modules-umd" data-module="cube" type="text/babel">
    export default function cube(x) {
      return x * x * x;
    }
  </script>
  <script data-plugins="transform-es2015-modules-umd" type="text/babel">
    import cube from 'cube'
    console.log(cube(3))
  </script>
</body>
</html>
```

Fixes #60, #71 