### PR TITLE
Point repo to babel

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+# `babel-standalone` is now part of `babel`! Go [check it out](https://github.com/babel/babel/tree/master/packages/babel-standalone) :warning::warning::warning::warning:
+
 babel-standalone
 ================
 


### PR DESCRIPTION
Looks like all of the good stuff is over in the babel repo now 🗡 

[rendered view](https://github.com/jeffrafter/babel-standalone/blob/62e7b7cfe590ec93fe1f69d923d536988a823341/README.md)