### PR TITLE
Reduce babel-env-standalone package size to ~170kb.

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,3 +91,14 @@ Custom plugins also work for inline `<script>`s:
 ```html
 <script type="text/babel" data-plugins="lolizer">
 ```
+
+Manually Building
+=================
+
+If you want to manually upgrade the Babel version used by babel-standalone (or build your own release), follow these steps:
+
+1. Upgrade the Babel versions in `package.json`. This can be done with `npm-check-upgrades` (eg. `npm-check-updates -u -a --packageFile ./package.json /^babel\-/`)
+2. Delete `node_modules`, as npm often produces inefficient directory layouts if you upgrade in-place
+3. Run `npm run build`
+4. Run `npm run test` to ensure it works
+5. Open `examples/example.htm` and ensure it works

--- a/README.md
+++ b/README.md
@@ -99,6 +99,6 @@ If you want to manually upgrade the Babel version used by babel-standalone (or b
 
 1. Upgrade the Babel versions in `package.json`. This can be done with `npm-check-upgrades` (eg. `npm-check-updates -u -a --packageFile ./package.json /^babel\-/`)
 2. Delete `node_modules`, as npm often produces inefficient directory layouts if you upgrade in-place
-3. Run `npm run build`
+3. Run `npm install && npm run build`
 4. Run `npm run test` to ensure it works
 5. Open `examples/example.htm` and ensure it works

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -61,7 +61,7 @@ function webpackBuild(filename, libraryName, version) {
         '../../../../src/babel-package-shim'
       ),
       new webpack.optimize.ModuleConcatenationPlugin(),
-    ].filter(Boolean)
+    ]
   };
 
   if (libraryName !== 'Babel') {

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -39,6 +39,7 @@ function webpackBuild(filename, libraryName, version) {
     plugins: [
       new webpack.DefinePlugin({
         'process.env.NODE_ENV': '"production"',
+        'process.env': JSON.stringify({ NODE_ENV: "production" }),
         BABEL_VERSION: JSON.stringify(require('babel-core/package.json').version),
         VERSION: JSON.stringify(version),
       }),
@@ -52,11 +53,15 @@ function webpackBuild(filename, libraryName, version) {
         require.resolve('./src/available-plugins')
       ),
       new webpack.NormalModuleReplacementPlugin(
+        /caniuse\-lite\/data\/regions\/.+/,
+        require.resolve('./src/caniuse-lite-regions')
+      ),
+      new webpack.NormalModuleReplacementPlugin(
         /..\/..\/package/,
         '../../../../src/babel-package-shim'
       ),
       new webpack.optimize.ModuleConcatenationPlugin(),
-    ]
+    ].filter(Boolean)
   };
 
   if (libraryName !== 'Babel') {

--- a/package.json
+++ b/package.json
@@ -117,7 +117,7 @@
     "babel-preset-es2015": "7.0.0-alpha.18",
     "babel-preset-es2016": "7.0.0-alpha.18",
     "babel-preset-es2017": "7.0.0-alpha.18",
-    "babel-preset-env": "2.0.0-alpha.18",
+    "babel-preset-env": "2.0.0-beta.2",
     "babel-preset-latest": "6.24.1",
     "babel-preset-react": "7.0.0-alpha.18",
     "babel-preset-stage-0": "7.0.0-alpha.18",

--- a/package.json
+++ b/package.json
@@ -92,6 +92,7 @@
     "babel-plugin-transform-member-expression-literals": "6.8.4",
     "babel-plugin-transform-merge-sibling-variables": "6.8.5",
     "babel-plugin-transform-minify-booleans": "6.8.2",
+    "babel-plugin-transform-new-target": "^7.0.0-alpha.14",
     "babel-plugin-transform-node-env-inline": "6.8.0",
     "babel-plugin-transform-object-assign": "7.0.0-alpha.18",
     "babel-plugin-transform-object-rest-spread": "7.0.0-alpha.18",

--- a/src/available-plugins.js
+++ b/src/available-plugins.js
@@ -1,1 +1,13 @@
-export { availablePlugins as default } from 'babel-standalone';
+import { availablePlugins } from "babel-standalone";
+
+const notIncludedPlugins = {
+  "transform-new-target": require("babel-plugin-transform-new-target"),
+};
+
+Object.keys(notIncludedPlugins).forEach(pluginName => {
+  if (!availablePlugins[pluginName]) {
+    availablePlugins[pluginName] = notIncludedPlugins[pluginName];
+  }
+});
+
+export default availablePlugins;

--- a/src/caniuse-lite-regions.js
+++ b/src/caniuse-lite-regions.js
@@ -1,0 +1,1 @@
+module.exports = {};


### PR DESCRIPTION
*Before*
<img width="446" alt="screen shot 2017-09-29 at 16 53 14" src="https://user-images.githubusercontent.com/1521229/31019233-af4c1182-a537-11e7-8028-a23765e12a97.png">
*After*
<img width="379" alt="screen shot 2017-09-29 at 16 53 03" src="https://user-images.githubusercontent.com/1521229/31019230-ad400ccc-a537-11e7-8d60-0afe3479fcd7.png">

@Daniel15 I know that it's deprecated repo, but it still the main standalone repo for the preset-env. So unless we don't move babel-preset-env to the [babel/babel](https://github.com/babel/babel), I think the only way is to support this one.
This PR just reduces bundle size and adds `babel-plugin-transform-new-target` for babel-standalone.
I've [created PR](https://github.com/babel/babel/pull/6322) to the original standalone repo, but it would be useful for previous versions. It's tiny.

I'm thinking to add stage-3 plugins also, but they are too large, so it's better to manually load them in specific cases (stage-3 checkbox for the REPL enabled for ex.) and add them directly to `Babel.availablePlugins[stage3PluginName]`. Then presetEnvStandalone can get them and use.

I've almost finished PR to the REPL which enables new features, so would be nice if you publish package after the merge 😊.