### PR TITLE
Remove the additional function context on DOMContentLoaded

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -257,7 +257,7 @@ export const version = VERSION;
 // Listen for load event if we're in a browser and then kick off finding and
 // running of scripts with "text/babel" type.
 if (typeof window !== 'undefined' && window && window.addEventListener) {
-  window.addEventListener('DOMContentLoaded', () => transformScriptTags(), false);
+  window.addEventListener('DOMContentLoaded', transformScriptTags, false);
 }
 
 /**


### PR DESCRIPTION
https://github.com/babel/babel-standalone/blob/2de2811b1ac4ca373f5fc0125f765932408ebe46/src/index.js#L260

https://github.com/babel/babel-standalone/blob/2de2811b1ac4ca373f5fc0125f765932408ebe46/src/index.js#L275

This is so wrong. No wonder I cannot remove the listener because the reference is different.